### PR TITLE
feat: 카테고리 엔티티,카테고리 재귀 호출

### DIFF
--- a/src/main/java/shop/wannab/book_service/controller/CategoryController.java
+++ b/src/main/java/shop/wannab/book_service/controller/CategoryController.java
@@ -1,0 +1,23 @@
+package shop.wannab.book_service.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shop.wannab.book_service.entity.category.dto.CategoryHierarchyDto;
+import shop.wannab.book_service.service.CategoryService;
+
+@RestController
+@RequiredArgsConstructor
+public class CategoryController {
+    private final CategoryService categoryService;
+
+
+    // front-service가 호출할 API 엔드포인트
+    @GetMapping("/api/categories/hierarchy")
+    public ResponseEntity<List<CategoryHierarchyDto>> getCategoryHierarchy() {
+        return ResponseEntity.ok(categoryService.getCategoryHierarchy());
+    }
+
+}

--- a/src/main/java/shop/wannab/book_service/entity/category/Category.java
+++ b/src/main/java/shop/wannab/book_service/entity/category/Category.java
@@ -1,0 +1,41 @@
+package shop.wannab.book_service.entity.category;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Category {
+
+    @Id
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @ManyToOne(fetch= FetchType.LAZY)
+    @JoinColumn(name= "parent_id")
+    private Category parent;
+
+    //자식 조회할때 사용
+    @OneToMany(mappedBy = "parent",fetch = FetchType.EAGER)
+    private List<Category> children = new ArrayList<>();
+
+    public Category(Long id, String name, Category parent) {
+        this.id = id;
+        this.name = name;
+        this.parent = parent;
+    }
+}

--- a/src/main/java/shop/wannab/book_service/entity/category/dto/CategoryHierarchyDto.java
+++ b/src/main/java/shop/wannab/book_service/entity/category/dto/CategoryHierarchyDto.java
@@ -1,0 +1,34 @@
+package shop.wannab.book_service.entity.category.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import shop.wannab.book_service.entity.category.Category;
+
+@Getter
+@Setter
+public class CategoryHierarchyDto {
+    private Long id;
+    private String name;
+    private List<CategoryHierarchyDto> children;
+
+    // Entity를 DTO로 변환하는 재귀적 생성자
+    // 최상위 카테고리 예시 : IT/모바일
+    public CategoryHierarchyDto(Category category) {
+        this.id = category.getId();
+        this.name = category.getName();
+        List<CategoryHierarchyDto> childDtoList = new ArrayList<>();
+
+        // IT/모바일에 하위 카테고리인 [네트워크,데이터베이스,자료구조,알고리즘,정보통신,...]
+        if (category.getChildren() != null && !category.getChildren().isEmpty()) {
+            // IT/모바일에 하위 카테고리들을 for each문으로 순차적 순회
+            for (Category childEntity : category.getChildren()) {
+                // IT/모바일에 하위 카테고리 또한 생성자 호출 -> 재귀적 구조 완성
+                CategoryHierarchyDto childDto = new CategoryHierarchyDto(childEntity);
+                childDtoList.add(childDto);
+            }
+        }
+        this.children = childDtoList;
+    }
+}

--- a/src/main/java/shop/wannab/book_service/repository/CategoryRepository.java
+++ b/src/main/java/shop/wannab/book_service/repository/CategoryRepository.java
@@ -1,0 +1,9 @@
+package shop.wannab.book_service.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import shop.wannab.book_service.entity.category.Category;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    List<Category> findByParentIsNull();
+}

--- a/src/main/java/shop/wannab/book_service/service/CategoryService.java
+++ b/src/main/java/shop/wannab/book_service/service/CategoryService.java
@@ -1,0 +1,32 @@
+package shop.wannab.book_service.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.wannab.book_service.entity.category.Category;
+import shop.wannab.book_service.entity.category.dto.CategoryHierarchyDto;
+import shop.wannab.book_service.repository.CategoryRepository;
+
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+
+    //재귀적으로 카테고리를 반환해주는 코드
+    @Transactional(readOnly = true)
+    public List<CategoryHierarchyDto> getCategoryHierarchy() {
+        //최상위 카테고리 호출
+        List<Category> rootCategories = categoryRepository.findByParentIsNull();
+
+        List<CategoryHierarchyDto> categoryHierarchyDtoList = new ArrayList<>();
+
+        for (Category rootCategory : rootCategories) {
+            CategoryHierarchyDto dto = new CategoryHierarchyDto(rootCategory);
+            categoryHierarchyDtoList.add(dto);
+        }
+        return categoryHierarchyDtoList;
+    }
+}


### PR DESCRIPTION
- 제목 : <20/이슈이름 : 카테고리 엔티티,조회 기능>

## 🥳 어떤 기능을 구현했나요?

> 도서의 카테고리 초기 세팅

## 🔎 작업 상세 내용
- CategoryController
- CategoryService
- Category(Entity)
- CategoryRepository
- Dto

- [ ] 카테고리 쿠폰 발급
- [ ] 카테고리로 도서 조회
      
## ⏰ Pull Request 마감시간
> 21일 오후 3시

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #이슈번호

코드 이해를 위한 설명
카테고리는 ERD에서 셀프 조인으로 재귀적인 성격을 띄기 때문에 자바 코드또한 재귀적으로 처리
하지만 조금 복잡하기 때문에 해당 코드를 읽는 팀원은 궁금하다면 한번쯤 읽어보는걸 추천합니다!
단계적으로 설명

데이터 처리 흐름

GET /api/categories/hierarchy 요청 수신
CategoryService에서 최상위 카테고리 조회
CategoryHierarchyDto 생성자의 재귀 호출을 통해 전체 트리 구조 생성
완성된 DTO 리스트를 JSON으로 응답
DFS라고 생각하고 흐름도를 따라가보시면 이해하기 편하실거같습니다.
