### PR TITLE
#22/관리자 도서 등록시 알라딘 API 연동 구현 완료

### DIFF
--- a/http/aladinAPI.http
+++ b/http/aladinAPI.http
@@ -1,0 +1,6 @@
+POST localhost:8081/api/aladin
+Content-Type: application/json
+
+{
+    "query" : "경제"
+}

--- a/http/aladinAPI.http
+++ b/http/aladinAPI.http
@@ -1,4 +1,4 @@
-POST localhost:8081/api/aladin
+POST localhost:8081/api/aladin/books/search
 Content-Type: application/json
 
 {

--- a/pom.xml
+++ b/pom.xml
@@ -86,14 +86,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 
 		<dependency>
@@ -104,6 +101,12 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-config</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-openfeign</artifactId>
+			<version>4.1.2</version>
 		</dependency>
 
 	</dependencies>

--- a/src/main/java/shop/wannab/book_service/BookServiceApplication.java
+++ b/src/main/java/shop/wannab/book_service/BookServiceApplication.java
@@ -3,8 +3,10 @@ package shop.wannab.book_service;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 @EnableDiscoveryClient
 public class BookServiceApplication {
 

--- a/src/main/java/shop/wannab/book_service/advice/BookControllerAdvice.java
+++ b/src/main/java/shop/wannab/book_service/advice/BookControllerAdvice.java
@@ -4,7 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import shop.wannab.book_service.entity.dto.OrderItemValidationError;
-import shop.wannab.book_service.exception.UnavailableOrderBooksException;
+import shop.wannab.book_service.global.exception.UnavailableOrderBooksException;
 
 import java.util.List;
 

--- a/src/main/java/shop/wannab/book_service/aladin/client/AladinClient.java
+++ b/src/main/java/shop/wannab/book_service/aladin/client/AladinClient.java
@@ -6,6 +6,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import shop.wannab.book_service.aladin.client.response.SearchResponse;
 
+/**
+ * 알라딘 API 에 요청을 보내는 FeignClient
+ *
+ * @author hunmin
+ */
 @FeignClient(name = "aladinClient", url = "${aladin.api.base-url}")
 public interface AladinClient {
 

--- a/src/main/java/shop/wannab/book_service/aladin/client/AladinClient.java
+++ b/src/main/java/shop/wannab/book_service/aladin/client/AladinClient.java
@@ -1,0 +1,15 @@
+package shop.wannab.book_service.aladin.client;
+
+import java.util.Map;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import shop.wannab.book_service.aladin.client.response.SearchResponse;
+
+@FeignClient(name = "aladinClient", url = "${aladin.api.base-url}")
+public interface AladinClient {
+
+    @GetMapping("/ItemSearch.aspx")
+    SearchResponse fetchFromAladin(@RequestParam Map<String, Object> params);
+}
+

--- a/src/main/java/shop/wannab/book_service/aladin/client/request/SearchRequest.java
+++ b/src/main/java/shop/wannab/book_service/aladin/client/request/SearchRequest.java
@@ -5,7 +5,11 @@ import java.util.Map;
 import lombok.Builder;
 import shop.wannab.book_service.aladin.controller.request.BookInfoRequest;
 
-
+/**
+ * 알라딘에 실제로 요청을 보내기 위한 Request 객체
+ *
+ * @author hunmin
+ */
 @Builder
 public record SearchRequest(
         String query,

--- a/src/main/java/shop/wannab/book_service/aladin/client/request/SearchRequest.java
+++ b/src/main/java/shop/wannab/book_service/aladin/client/request/SearchRequest.java
@@ -1,0 +1,49 @@
+package shop.wannab.book_service.aladin.client.request;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Builder;
+import shop.wannab.book_service.aladin.controller.request.BookInfoRequest;
+
+
+@Builder
+public record SearchRequest(
+        String query,
+        String queryType,
+        String searchTarget,
+        Integer start,
+        Integer maxResults,
+        String sort,
+        String cover,
+        Integer categoryId
+) {
+
+    public static SearchRequest from(BookInfoRequest req) {
+        return SearchRequest.builder()
+                .query(req.query())
+                .queryType(req.queryType() != null ? req.queryType().name() : "Keyword")
+                .searchTarget(req.searchTarget() != null ? req.searchTarget().name() : "Book")
+                .start(req.start() != null ? req.start() : 1)
+                .maxResults(req.maxResults() != null ? req.maxResults() : 100)
+                .sort(req.sort() != null ? req.sort().name() : "Accuracy")
+                .cover(req.cover() != null ? req.cover().name() : "Mid")
+                .categoryId(req.categoryId() != null ? req.categoryId() : 0)
+                .build();
+    }
+
+    public Map<String, Object> toParamMap(String ttbKey) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("ttbkey", ttbKey);
+        map.put("Query", query);
+        map.put("QueryType", queryType);
+        map.put("SearchTarget", searchTarget);
+        map.put("start", start);
+        map.put("MaxResults", maxResults);
+        map.put("Sort", sort);
+        map.put("Cover", cover);
+        map.put("CategoryId", categoryId);
+        map.put("output", "JS");
+        map.put("Version", "20131101");
+        return map;
+    }
+}

--- a/src/main/java/shop/wannab/book_service/aladin/client/response/BookItem.java
+++ b/src/main/java/shop/wannab/book_service/aladin/client/response/BookItem.java
@@ -1,0 +1,29 @@
+package shop.wannab.book_service.aladin.client.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.time.LocalDate;
+import java.util.List;
+import shop.wannab.book_service.global.deserializer.CommaSeparatedToListDeserializer;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BookItem(
+        String title,
+        @JsonDeserialize(using = CommaSeparatedToListDeserializer.class)
+        List<String> author,
+        LocalDate pubDate,
+        String description,
+        String isbn,
+        String isbn13,
+        String itemId,
+        Integer priceSales,
+        Integer priceStandard,
+        String mallType,
+        Integer mileage,
+        String cover,
+        String categoryId,
+        String categoryName,
+        @JsonDeserialize(using = CommaSeparatedToListDeserializer.class)
+        List<String> publisher
+) {
+}

--- a/src/main/java/shop/wannab/book_service/aladin/client/response/BookItem.java
+++ b/src/main/java/shop/wannab/book_service/aladin/client/response/BookItem.java
@@ -6,6 +6,11 @@ import java.time.LocalDate;
 import java.util.List;
 import shop.wannab.book_service.global.deserializer.CommaSeparatedToListDeserializer;
 
+/**
+ * 알라딘에서 받는 BookItem 객체
+ *
+ * @author hunmin
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record BookItem(
         String title,

--- a/src/main/java/shop/wannab/book_service/aladin/client/response/SearchResponse.java
+++ b/src/main/java/shop/wannab/book_service/aladin/client/response/SearchResponse.java
@@ -1,0 +1,20 @@
+package shop.wannab.book_service.aladin.client.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SearchResponse(
+    String title,
+    Integer totalResults,
+    Integer startIndex,
+    Integer ItemsPerPage,
+    String query,
+    String searchCategoryId,
+    String searchCategoryName,
+
+    @JsonProperty("item")
+    List<BookItem> items
+) {
+}

--- a/src/main/java/shop/wannab/book_service/aladin/client/response/SearchResponse.java
+++ b/src/main/java/shop/wannab/book_service/aladin/client/response/SearchResponse.java
@@ -4,6 +4,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
+/**
+ * 알라딘에서 검색을 통해 받는 래핑된 응답 객체
+ *
+ * @author hunmin
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record SearchResponse(
     String title,

--- a/src/main/java/shop/wannab/book_service/aladin/controller/AladinController.java
+++ b/src/main/java/shop/wannab/book_service/aladin/controller/AladinController.java
@@ -1,0 +1,26 @@
+package shop.wannab.book_service.aladin.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shop.wannab.book_service.aladin.controller.request.BookInfoRequest;
+import shop.wannab.book_service.aladin.controller.response.BookInfoResponse;
+import shop.wannab.book_service.aladin.service.AladinService;
+
+@RestController
+@RequestMapping("/api/aladin")
+@RequiredArgsConstructor
+public class AladinController {
+
+    private final AladinService aladinService;
+
+    @PostMapping
+    public BookInfoResponse getBooksInfo(@RequestBody @Valid BookInfoRequest request){
+        aladinService.searchBooks(request);
+        return null;
+    }
+
+}

--- a/src/main/java/shop/wannab/book_service/aladin/controller/AladinController.java
+++ b/src/main/java/shop/wannab/book_service/aladin/controller/AladinController.java
@@ -6,21 +6,22 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import shop.wannab.book_service.aladin.client.response.SearchResponse;
 import shop.wannab.book_service.aladin.controller.request.BookInfoRequest;
-import shop.wannab.book_service.aladin.controller.response.BookInfoResponse;
 import shop.wannab.book_service.aladin.service.AladinService;
 
 @RestController
-@RequestMapping("/api/aladin")
+@RequestMapping("/api/admin/aladin")
 @RequiredArgsConstructor
 public class AladinController {
 
     private final AladinService aladinService;
 
-    @PostMapping
-    public BookInfoResponse getBooksInfo(@RequestBody @Valid BookInfoRequest request){
-        aladinService.searchBooks(request);
-        return null;
+    @PostMapping("/books/search")
+    public SearchResponse getBooksInfo(@RequestBody @Valid BookInfoRequest request){
+        return aladinService.searchBooks(request);
     }
+
+
 
 }

--- a/src/main/java/shop/wannab/book_service/aladin/controller/request/BookInfoRequest.java
+++ b/src/main/java/shop/wannab/book_service/aladin/controller/request/BookInfoRequest.java
@@ -1,0 +1,35 @@
+package shop.wannab.book_service.aladin.controller.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import shop.wannab.book_service.aladin.domain.AladinEnums.CoverOption;
+import shop.wannab.book_service.aladin.domain.AladinEnums.QueryType;
+import shop.wannab.book_service.aladin.domain.AladinEnums.SearchTarget;
+import shop.wannab.book_service.aladin.domain.AladinEnums.SortOption;
+
+/**
+ * 알라딘 검색 API 활용하기 위한 관리자 요청 객체
+ *
+ * @param query 검색어
+ * @param queryType 검색어 종류
+ * @param searchTarget 검색 대상 (도서, 음반, DVD 등)
+ * @param start 검색 결과 시작페이지
+ * @param maxResults 최대 검색 수
+ * @param sort 정렬 순서 (관련도, 출간일, 제목 등)
+ * @param cover 표지 이미지 크기
+ * @param categoryId 특정 카테고리 고유 번호
+ *
+ * @author hunmin
+ */
+public record BookInfoRequest(
+        @NotBlank String query,
+        QueryType queryType,
+        SearchTarget searchTarget,
+        @Min(1) Integer start,
+        @Max(200) Integer maxResults,
+        SortOption sort,
+        CoverOption cover,
+        @Min(0) Integer categoryId
+) {
+}

--- a/src/main/java/shop/wannab/book_service/aladin/controller/response/BookInfoResponse.java
+++ b/src/main/java/shop/wannab/book_service/aladin/controller/response/BookInfoResponse.java
@@ -1,0 +1,4 @@
+package shop.wannab.book_service.aladin.controller.response;
+
+public record BookInfoResponse() {
+}

--- a/src/main/java/shop/wannab/book_service/aladin/controller/response/BookInfoResponse.java
+++ b/src/main/java/shop/wannab/book_service/aladin/controller/response/BookInfoResponse.java
@@ -1,4 +1,0 @@
-package shop.wannab.book_service.aladin.controller.response;
-
-public record BookInfoResponse() {
-}

--- a/src/main/java/shop/wannab/book_service/aladin/domain/AladinEnums.java
+++ b/src/main/java/shop/wannab/book_service/aladin/domain/AladinEnums.java
@@ -1,0 +1,39 @@
+package shop.wannab.book_service.aladin.domain;
+
+public class AladinEnums {
+    public enum QueryType {
+        Keyword("제목, 저자"), Title("제목"), Author("저자"), Publisher("출판사");
+        public final String description;
+
+        QueryType(String description) {
+            this.description = description;
+        }
+    }
+
+    public enum SearchTarget {
+        Book("도서"), Foreign("외국 도서"), Music("음반"), DVD("DVD"), Used("중고"), eBook("전자책"), All("무관");
+        public final String description;
+
+        SearchTarget(String description) {
+            this.description = description;
+        }
+    }
+
+    public enum SortOption {
+        Accuracy("관련도"), PublishTime("출간일"), Title("제목"), SalesPoint("판매량"), CustomerRating("고객평점");
+        public final String description;
+
+        SortOption(String description) {
+            this.description = description;
+        }
+    }
+
+    public enum CoverOption {
+        Big("200px"), MidBig("150px"), Mid("85px"), Small("75px"), Mini("65px"), None("0px");
+        public final String description;
+
+        CoverOption(String description) {
+            this.description = description;
+        }
+    }
+}

--- a/src/main/java/shop/wannab/book_service/aladin/domain/AladinEnums.java
+++ b/src/main/java/shop/wannab/book_service/aladin/domain/AladinEnums.java
@@ -1,5 +1,10 @@
 package shop.wannab.book_service.aladin.domain;
 
+/**
+ * 관리자가 알라딘 API를 활용해 책 정보를 검색할 시 사용하는 클래스
+ *
+ * @author hunmin
+ */
 public class AladinEnums {
     public enum QueryType {
         Keyword("제목, 저자"), Title("제목"), Author("저자"), Publisher("출판사");

--- a/src/main/java/shop/wannab/book_service/aladin/exception/AladinApiException.java
+++ b/src/main/java/shop/wannab/book_service/aladin/exception/AladinApiException.java
@@ -1,0 +1,13 @@
+package shop.wannab.book_service.aladin.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AladinApiException extends RuntimeException {
+    private final AladinErrorCode errorCode;
+
+    public AladinApiException(AladinErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/shop/wannab/book_service/aladin/exception/AladinErrorCode.java
+++ b/src/main/java/shop/wannab/book_service/aladin/exception/AladinErrorCode.java
@@ -1,0 +1,16 @@
+package shop.wannab.book_service.aladin.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AladinErrorCode {
+    ALDIN_API_ERROR(HttpStatus.BAD_GATEWAY, "ALD001", "알라딘 API 호출 실패"),
+    TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "ALD002", "알라딘 응답 지연");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/shop/wannab/book_service/aladin/exception/response/AladinErrorResponse.java
+++ b/src/main/java/shop/wannab/book_service/aladin/exception/response/AladinErrorResponse.java
@@ -1,0 +1,12 @@
+package shop.wannab.book_service.aladin.exception.response;
+
+import shop.wannab.book_service.aladin.exception.AladinErrorCode;
+
+public record AladinErrorResponse(
+        String code,
+        String message
+) {
+    public AladinErrorResponse(AladinErrorCode errorCode) {
+        this(errorCode.getCode(), errorCode.getMessage());
+    }
+}

--- a/src/main/java/shop/wannab/book_service/aladin/service/AladinService.java
+++ b/src/main/java/shop/wannab/book_service/aladin/service/AladinService.java
@@ -1,13 +1,17 @@
 package shop.wannab.book_service.aladin.service;
 
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import shop.wannab.book_service.aladin.client.AladinClient;
 import shop.wannab.book_service.aladin.client.request.SearchRequest;
 import shop.wannab.book_service.aladin.client.response.SearchResponse;
 import shop.wannab.book_service.aladin.controller.request.BookInfoRequest;
+import shop.wannab.book_service.aladin.exception.AladinApiException;
+import shop.wannab.book_service.aladin.exception.AladinErrorCode;
 
 @Slf4j
 @Service
@@ -19,11 +23,13 @@ public class AladinService {
     @Value("${aladin.api.ttbkey}")
     private String ttbKey;
 
-    public String searchBooks(BookInfoRequest request) {
+    @Transactional(readOnly = true)
+    public SearchResponse searchBooks(BookInfoRequest request) {
         SearchRequest params = SearchRequest.from(request);
-        SearchResponse searchResponse = aladinClient.fetchFromAladin(params.toParamMap(ttbKey));
-        log.info("bookInfoResponse : {}", searchResponse);
-        return null;
+        try{
+            return aladinClient.fetchFromAladin(params.toParamMap(ttbKey));
+        } catch (FeignException e) {
+            throw new AladinApiException(AladinErrorCode.ALDIN_API_ERROR, e);
+        }
     }
-
 }

--- a/src/main/java/shop/wannab/book_service/aladin/service/AladinService.java
+++ b/src/main/java/shop/wannab/book_service/aladin/service/AladinService.java
@@ -1,0 +1,29 @@
+package shop.wannab.book_service.aladin.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import shop.wannab.book_service.aladin.client.AladinClient;
+import shop.wannab.book_service.aladin.client.request.SearchRequest;
+import shop.wannab.book_service.aladin.client.response.SearchResponse;
+import shop.wannab.book_service.aladin.controller.request.BookInfoRequest;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AladinService {
+
+    private final AladinClient aladinClient;
+
+    @Value("${aladin.api.ttbkey}")
+    private String ttbKey;
+
+    public String searchBooks(BookInfoRequest request) {
+        SearchRequest params = SearchRequest.from(request);
+        SearchResponse searchResponse = aladinClient.fetchFromAladin(params.toParamMap(ttbKey));
+        log.info("bookInfoResponse : {}", searchResponse);
+        return null;
+    }
+
+}

--- a/src/main/java/shop/wannab/book_service/config/ObjectMapperConfig.java
+++ b/src/main/java/shop/wannab/book_service/config/ObjectMapperConfig.java
@@ -1,0 +1,25 @@
+package shop.wannab.book_service.config;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Enum 대소문자 상관없이 매핑될 수 있도록 커스텀 설정하는 클래스
+ *
+ * @author hunmin
+ */
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper(){
+        return JsonMapper.builder()
+                .addModule(new JavaTimeModule())
+                .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true)
+                .build();
+    }
+}

--- a/src/main/java/shop/wannab/book_service/global/advice/GlobalExceptionHandler.java
+++ b/src/main/java/shop/wannab/book_service/global/advice/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package shop.wannab.book_service.global.advice;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import shop.wannab.book_service.aladin.exception.AladinApiException;
+import shop.wannab.book_service.aladin.exception.AladinErrorCode;
+import shop.wannab.book_service.aladin.exception.response.AladinErrorResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AladinApiException.class)
+    public ResponseEntity<AladinErrorResponse> handleExternalApiException(AladinApiException ex) {
+        AladinErrorCode code = ex.getErrorCode();
+        return ResponseEntity
+                .status(code.getHttpStatus())
+                .body(new AladinErrorResponse(code));
+    }
+}

--- a/src/main/java/shop/wannab/book_service/global/config/ObjectMapperConfig.java
+++ b/src/main/java/shop/wannab/book_service/global/config/ObjectMapperConfig.java
@@ -1,4 +1,4 @@
-package shop.wannab.book_service.config;
+package shop.wannab.book_service.global.config;
 
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/shop/wannab/book_service/global/config/RedisConfig.java
+++ b/src/main/java/shop/wannab/book_service/global/config/RedisConfig.java
@@ -1,4 +1,4 @@
-package shop.wannab.book_service.config;
+package shop.wannab.book_service.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/shop/wannab/book_service/global/deserializer/CommaSeparatedToListDeserializer.java
+++ b/src/main/java/shop/wannab/book_service/global/deserializer/CommaSeparatedToListDeserializer.java
@@ -1,0 +1,19 @@
+package shop.wannab.book_service.global.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class CommaSeparatedToListDeserializer extends JsonDeserializer<List<String>> {
+
+    @Override
+    public List<String> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        String raw = p.getText();
+        if (raw == null || raw.isBlank()) return Collections.emptyList();
+        return Arrays.stream(raw.split(",")).map(String::trim).toList();
+    }
+}

--- a/src/main/java/shop/wannab/book_service/global/exception/UnavailableOrderBooksException.java
+++ b/src/main/java/shop/wannab/book_service/global/exception/UnavailableOrderBooksException.java
@@ -1,4 +1,4 @@
-package shop.wannab.book_service.exception;
+package shop.wannab.book_service.global.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/shop/wannab/book_service/service/BookService.java
+++ b/src/main/java/shop/wannab/book_service/service/BookService.java
@@ -3,7 +3,7 @@ package shop.wannab.book_service.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import shop.wannab.book_service.entity.dto.*;
-import shop.wannab.book_service.exception.UnavailableOrderBooksException;
+import shop.wannab.book_service.global.exception.UnavailableOrderBooksException;
 import shop.wannab.book_service.repository.BookRepository;
 
 import java.util.*;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,3 +15,8 @@ server:
 eureka:
   client:
     enabled: false
+
+aladin:
+  api:
+    base-url: "http://www.aladin.co.kr/ttb/api/"
+    ttbkey: "dummy-ttb-key-for-ci"

--- a/src/test/java/shop/wannab/book_service/service/BookServiceTest.java
+++ b/src/test/java/shop/wannab/book_service/service/BookServiceTest.java
@@ -8,7 +8,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import shop.wannab.book_service.entity.Book;
 import shop.wannab.book_service.entity.dto.CartItem;
 import shop.wannab.book_service.entity.dto.OrderItemListDto;
-import shop.wannab.book_service.exception.UnavailableOrderBooksException;
+import shop.wannab.book_service.global.exception.UnavailableOrderBooksException;
 import shop.wannab.book_service.repository.BookRepository;
 
 import java.util.List;


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?
> 관리자가 도서를 등록 시, 알라딘 API를 활용해 등록할 수 있도록 구현하였습니다

## 🔎 작업 상세 내용

- [x] 알라딘 API 키 발급
- [x] 알라딘 API 데이터 정제
- [x] 데이터 정제 후 도서 등록 시 활용할 수 있도록 구현
      
## ⏰ Pull Request 마감시간
> 6월 25일 17시 30분

## 🔗 관련 이슈
Closes #22
