### PR TITLE
issue-35/도서 재고 증감 로직 구현

### DIFF
--- a/src/main/java/shop/wannab/book_service/book/controller/BookController.java
+++ b/src/main/java/shop/wannab/book_service/book/controller/BookController.java
@@ -47,6 +47,11 @@ public class BookController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/increase-stock")
+    ResponseEntity<Void> increaseStock(@RequestBody OrderItemListDto orderItemListDto) {
+        bookService.increaseStock(orderItemListDto);
+        return ResponseEntity.ok().build();
+    }
     // 도서 좋아요 등록
     @PostMapping("/{book-id}/likes")
     public ResponseEntity<ApiResponse<Void>> createBookLike(@PathVariable("book-id") Long bookId,

--- a/src/main/java/shop/wannab/book_service/book/entity/Book.java
+++ b/src/main/java/shop/wannab/book_service/book/entity/Book.java
@@ -83,11 +83,4 @@ public class Book {
         this.status = status;
     }
 
-    //재고감소
-    public void decreaseStock(int quantity) {
-        if (this.stock < quantity) {
-            throw new IllegalStateException("재고 부족");
-        }
-        this.stock -= quantity;
-    }
 }

--- a/src/main/java/shop/wannab/book_service/book/repository/BookRedisRepository.java
+++ b/src/main/java/shop/wannab/book_service/book/repository/BookRedisRepository.java
@@ -2,4 +2,8 @@ package shop.wannab.book_service.book.repository;
 
 public interface BookRedisRepository {
     Integer getBookStock(long bookId);
+
+    void decreaseBookStock(long bookId, int amount);
+
+    void increaseBookStock(long bookId, int amount);
 }

--- a/src/main/java/shop/wannab/book_service/book/repository/impl/BookRedisRepositoryImpl.java
+++ b/src/main/java/shop/wannab/book_service/book/repository/impl/BookRedisRepositoryImpl.java
@@ -17,4 +17,14 @@ public class BookRedisRepositoryImpl implements BookRedisRepository {
         Integer stock = (Integer) redisTemplate.opsForHash().get(BOOK_STOCK_KEY, bookId);
         return stock;
     }
+
+    @Override
+    public void decreaseBookStock(long bookId, int amount) {
+        redisTemplate.opsForHash().increment(BOOK_STOCK_KEY, bookId, amount);
+    }
+
+    @Override
+    public void increaseBookStock(long bookId, int amount) {
+        redisTemplate.opsForHash().increment(BOOK_STOCK_KEY, bookId, -amount);
+    }
 }

--- a/src/main/java/shop/wannab/book_service/book/service/BookService.java
+++ b/src/main/java/shop/wannab/book_service/book/service/BookService.java
@@ -107,22 +107,17 @@ public class BookService {
         List<CartItem> orderItems = orderItemListDto.getOrderItems();
         List<OrderItemValidationError> errors = new ArrayList<>();
 
-        Map<Long, Integer> quantityMap = new HashMap<>();
-        List<Book> booksToUpdate = new ArrayList<>();
-
         for (CartItem orderItem : orderItems) {
             long bookId = orderItem.getBookId();
             int quantity = orderItem.getQuantity();
-            quantityMap.put(bookId, quantity);
 
-            Book book = bookRepository.findById(bookId).orElse(null);
-
-            if (book == null) {
+            Integer stock = bookRepository.getBookStock(bookId);
+            if (stock == null) {
                 errors.add(new OrderItemValidationError(bookId, "해당 상품을 찾을 수 없습니다."));
                 continue;
             }
 
-            if (quantity > book.getStock()) {
+            if (quantity > stock) {
                 errors.add(new OrderItemValidationError(bookId, "재고가 부족합니다."));
                 continue;
             }
@@ -132,18 +127,13 @@ public class BookService {
                 continue;
             }
 
-            booksToUpdate.add(book);
+            bookRepository.decreaseBookStock(bookId, quantity);
 
         }
         if (!errors.isEmpty()) {
             throw new UnavailableOrderBooksException(errors);
         }
 
-        //모든 검증이 문제가 없으면 재고 감소
-        for (Book book : booksToUpdate) {
-            int quantity = quantityMap.get(book.getBookId());
-            book.decreaseStock(quantity);
-        }
     }
 
     // 도서 상세 조회
@@ -186,5 +176,28 @@ public class BookService {
             throw new BookApiException(BookErrorCode.BOOK_NOT_FOUND);
         }
         return bookLikeRepository.existsByUserIdAndBook_BookId(userId,bookId);
+    }
+
+    @Transactional
+    public void increaseStock(OrderItemListDto orderItemListDto) {
+        List<CartItem> orderItems = orderItemListDto.getOrderItems();
+        List<OrderItemValidationError> errors = new ArrayList<>();
+
+        for (CartItem orderItem : orderItems) {
+            long bookId = orderItem.getBookId();
+            int quantity = orderItem.getQuantity();
+
+            Book book = bookRepository.findById(bookId).orElse(null);
+
+            if (book == null) {
+                errors.add(new OrderItemValidationError(bookId, "해당 상품을 찾을 수 없습니다."));
+                continue;
+            }
+            bookRepository.increaseBookStock(bookId, quantity);
+        }
+        if (!errors.isEmpty()) {
+            throw new UnavailableOrderBooksException(errors);
+        }
+
     }
 }


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?

레디스에 저장한 도서 재고 증감 기능 구현

## 🔎 작업 상세 내용

1. 주문시 재고감소 로직 수정
2. 주문취소/반품시
bookId, Quantity를 필드로 갖는 Dto의 리스트를 파라미터로 받아
bookId로 도서가 존재하는지 여부 파악후 도서의 재고를 증가(레디스)
      
## ⏰ Pull Request 마감시간
> 6.30.18h

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #35 
