### PR TITLE
73/fix: 존재하지 않는 도서 장바구니,주문에서 제외

### DIFF
--- a/src/main/java/shop/wannab/book_service/book/dto/BookIdTitlePriceProjection.java
+++ b/src/main/java/shop/wannab/book_service/book/dto/BookIdTitlePriceProjection.java
@@ -1,7 +1,7 @@
 package shop.wannab.book_service.book.dto;
 
 public interface BookIdTitlePriceProjection {
-    long getBookId();
+    Long getBookId();
     String getTitle();
-    int getSalesPrice();
+    Integer getSalesPrice();
 }

--- a/src/main/java/shop/wannab/book_service/book/dto/BookInfoForOrderProjection.java
+++ b/src/main/java/shop/wannab/book_service/book/dto/BookInfoForOrderProjection.java
@@ -1,8 +1,8 @@
 package shop.wannab.book_service.book.dto;
 
 public interface BookInfoForOrderProjection {
-    long getBookId();
+    Long getBookId();
     String getTitle();
-    int getOriginPrice();
-    int getSalesPrice();
+    Integer getOriginPrice();
+    Integer getSalesPrice();
 }

--- a/src/main/java/shop/wannab/book_service/book/repository/BookRepository.java
+++ b/src/main/java/shop/wannab/book_service/book/repository/BookRepository.java
@@ -11,7 +11,12 @@ import shop.wannab.book_service.book.dto.BookIdTitlePriceProjection;
 import shop.wannab.book_service.book.dto.BookInfoForOrderProjection;
 import shop.wannab.book_service.book.entity.Book;
 public interface BookRepository extends JpaRepository<Book, Long>, BookRedisRepository {
+
     boolean existsByBookIdAndStatusTrue(long bookId);
+
+    @Query("SELECT b.bookId FROM books b WHERE b.bookId IN :bookIds")
+    List<Long> findBookIdByBookIdIn(List<Long> bookIds);
+
 
     List<BookInfoForOrderProjection> findByBookIdIn(List<Long> ids);
 

--- a/src/main/java/shop/wannab/book_service/book/service/impl/BookServiceImpl.java
+++ b/src/main/java/shop/wannab/book_service/book/service/impl/BookServiceImpl.java
@@ -73,17 +73,17 @@ public class BookServiceImpl implements BookService {
     @Transactional(readOnly = true)
     public OrderBookInfoListDto getOrderBookInfos(OrderItemListDto orderItemListDto) {
         List<CartItem> orderItems = orderItemListDto.getOrderItems();
-        orderItems.removeIf(cartItem -> cartItem.getBookId() == -1);
         List<Long> ids = orderItems.stream().map(CartItem::getBookId).collect(Collectors.toList());
+        List<Long> existingBookIds = bookRepository.findBookIdByBookIdIn(ids);
+        orderItems.removeIf(cartItem -> !existingBookIds.contains(cartItem.getBookId()));
 
-        List<BookInfoForOrderProjection> bookInfoList = bookRepository.findByBookIdIn(ids);
+        List<BookInfoForOrderProjection> bookInfoList = bookRepository.findByBookIdIn(existingBookIds);
 
         Map<Long, BookInfoForOrderProjection> bookInfoMap = new HashMap<>();
 
         for (BookInfoForOrderProjection projection : bookInfoList) {
             bookInfoMap.put(projection.getBookId(), projection);
         }
-
         List<OrderBookInfo> orderBookInfos = new ArrayList<>();
 
         for (CartItem item : orderItems) {


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?

장바구니에 추가하였지만 삭제된 도서를 장바구니, 주문에서 제외시킵니다.
## 🔎 작업 상세 내용

- [x] 도서테이블에서 장바구니에 담긴 도서가 존재하는지 확인 후 존재하지 않는다면 장바구니,주문페이지에서 제외(레디스에 남아있음)
- [x] 프로젝션 필드를 모두 wrapper type으로 변경
      
## ⏰ Pull Request 마감시간
> 7.10.14h

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #73 
