### PR TITLE
#91/알라딘 도서 저장 로직 리팩토링

### DIFF
--- a/src/main/java/shop/wannab/book_service/aladin/service/AladinService.java
+++ b/src/main/java/shop/wannab/book_service/aladin/service/AladinService.java
@@ -1,11 +1,8 @@
 package shop.wannab.book_service.aladin.service;
 
 import feign.FeignException;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.wannab.book_service.aladin.client.AladinClient;
@@ -14,24 +11,13 @@ import shop.wannab.book_service.aladin.client.response.SearchResponse;
 import shop.wannab.book_service.aladin.controller.request.BookInfoRequest;
 import shop.wannab.book_service.aladin.exception.AladinApiException;
 import shop.wannab.book_service.aladin.exception.AladinErrorCode;
-import shop.wannab.book_service.author.entity.Author;
-import shop.wannab.book_service.author.repository.AuthorRepository;
 import shop.wannab.book_service.book.controller.request.AladinBookCreateRequest;
 import shop.wannab.book_service.book.entity.Book;
-import shop.wannab.book_service.book.entity.BookAuthor;
-import shop.wannab.book_service.book.entity.BookCategory;
-import shop.wannab.book_service.book.entity.BookImage;
-import shop.wannab.book_service.book.entity.BookPublisher;
 import shop.wannab.book_service.book.exception.BookApiException;
 import shop.wannab.book_service.book.exception.BookErrorCode;
-import shop.wannab.book_service.book.repository.BookCategoryRepository;
+import shop.wannab.book_service.book.factory.BookAggregateFactory;
 import shop.wannab.book_service.book.repository.BookRepository;
-import shop.wannab.book_service.category.entity.Category;
-import shop.wannab.book_service.category.exception.CategoryApiException;
-import shop.wannab.book_service.category.exception.CategoryErrorCode;
-import shop.wannab.book_service.category.repository.CategoryRepository;
-import shop.wannab.book_service.publisher.entity.Publisher;
-import shop.wannab.book_service.publisher.repository.PublisherRepository;
+import shop.wannab.book_service.global.properties.AladinKeyProperties;
 
 @Slf4j
 @Service
@@ -40,19 +26,14 @@ public class AladinService {
 
     private final AladinClient aladinClient;
     private final BookRepository bookRepository;
-    private final AuthorRepository authorRepository;
-    private final PublisherRepository publisherRepository;
-    private final CategoryRepository categoryRepository;
-    private final BookCategoryRepository bookCategoryRepository;
-
-    @Value("${aladin.api.ttbkey}")
-    private String ttbKey;
+    private final BookAggregateFactory bookAggregateFactory;
+    private final AladinKeyProperties aladinKeyProperties;
 
     @Transactional(readOnly = true)
     public SearchResponse searchBooks(BookInfoRequest request) {
         SearchRequest params = SearchRequest.from(request);
         try{
-            return aladinClient.fetchFromAladin(params.toParamMap(ttbKey));
+            return aladinClient.fetchFromAladin(params.toParamMap(aladinKeyProperties.getTtbKey()));
         } catch (FeignException e) {
             throw new AladinApiException(AladinErrorCode.ALDIN_API_ERROR, e);
         }
@@ -61,88 +42,13 @@ public class AladinService {
 
     @Transactional
     public void aladinCreateBook(AladinBookCreateRequest request) {
-
         if (bookRepository.existsByIsbn(request.isbn())) {
             throw new BookApiException(BookErrorCode.DUPLICATE_BOOK);
         }
 
-        Book book = request.toEntity();
-        List<BookAuthor> bookAuthors = request.authors().stream()
-                .map(authorName ->{
-                    Author author = authorRepository.findAuthorsByAuthorName(authorName)
-                            .orElseGet(()->authorRepository.save(
-                                    Author.builder().authorName(authorName).build()));
-                    return BookAuthor.builder()
-                            .book(book)
-                            .author(author)
-                            .build();
-                }).toList();
-
-        List<BookPublisher> bookPublishers = request.publishers().stream()
-                .map(publisherName -> {
-                    Publisher publisher = publisherRepository.findPublisherByPublisherName(publisherName)
-                            .orElseGet(() -> publisherRepository.save(
-                                    Publisher.builder().publisherName(publisherName).build()));
-                    return BookPublisher.builder()
-                            .book(book)
-                            .publisher(publisher)
-                            .build();
-                }).toList();
-
-        BookImage bookImage = BookImage.builder()
-                .book(book)
-                .imageUrl(request.thumbnail())
-                .build();
-
-        List<BookImage> bookImages = List.of(bookImage);
-        List<BookCategory> categories = ensureCategoryHierarchy(request.category(),book);
-
-        book.getBookCategories().addAll(categories);
-        book.getBookImages().addAll(bookImages);
-        book.getBookAuthors().addAll(bookAuthors);
-        book.getBookPublishers().addAll(bookPublishers);
-
+        Book book = bookAggregateFactory.toAggregate(request);
 
         bookRepository.save(book);
-        bookRepository.saveOrUpdateBookStock(book.getBookId(),book.getStock());
-    }
-
-    private List<BookCategory> ensureCategoryHierarchy(List<String> categoryNames,Book book) {
-        if (categoryNames.size() < 2) {
-            throw new CategoryApiException(CategoryErrorCode.INVALID_CATEGORY_HIERARCHY);
-        }
-
-        List<BookCategory> categories = new ArrayList<>();
-
-        String parentName = categoryNames.get(1);
-        String childName = categoryNames.get(2);
-
-        Category parentCategory = categoryRepository.findByName(parentName)
-                .orElseGet(() -> {
-                    Category newParent = new Category();
-                    newParent.setName(parentName);
-                    return categoryRepository.save(newParent);
-                });
-
-        categories.add(BookCategory.builder()
-                .book(book)
-                .category(parentCategory)
-                .build());
-
-        Category childCategory = categoryRepository.findByName(childName)
-                .orElseGet(() -> {
-                    Category newChild = new Category();
-                    newChild.setName(childName);
-                    newChild.setParent(parentCategory);
-                    return categoryRepository.save(newChild);
-                });
-
-        categories.add(BookCategory.builder()
-                .book(book)
-                .category(childCategory)
-                .build());
-
-
-        return categories;
+        bookRepository.saveOrUpdateBookStock(book.getBookId(), book.getStock());
     }
 }

--- a/src/main/java/shop/wannab/book_service/author/entity/Author.java
+++ b/src/main/java/shop/wannab/book_service/author/entity/Author.java
@@ -20,4 +20,8 @@ public class Author {
     @NotNull
     @Column(length = 50)
     private String authorName;
+
+    public Author(String authorName) {
+        this.authorName = authorName;
+    }
 }

--- a/src/main/java/shop/wannab/book_service/author/repository/AuthorRepository.java
+++ b/src/main/java/shop/wannab/book_service/author/repository/AuthorRepository.java
@@ -1,5 +1,7 @@
 package shop.wannab.book_service.author.repository;
 
+import java.util.Collection;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import shop.wannab.book_service.author.entity.Author;
 
@@ -7,4 +9,5 @@ import java.util.Optional;
 
 public interface AuthorRepository extends JpaRepository<Author,Long> {
     Optional<Author> findAuthorsByAuthorName(String authorName);
+    List<Author> findAllByAuthorNameIn(Collection<String> authorNames);
 }

--- a/src/main/java/shop/wannab/book_service/book/controller/request/AladinBookCreateRequest.java
+++ b/src/main/java/shop/wannab/book_service/book/controller/request/AladinBookCreateRequest.java
@@ -24,7 +24,7 @@ public record AladinBookCreateRequest(
         Boolean status
 ) {
 
-    public Book toEntity(){
+    public Book toEntityWithOutAuthorAndPublisher(){
         return Book.builder()
                 .title(this.title)
                 .description(this.description)

--- a/src/main/java/shop/wannab/book_service/book/controller/request/BookCreateRequest.java
+++ b/src/main/java/shop/wannab/book_service/book/controller/request/BookCreateRequest.java
@@ -45,7 +45,7 @@ public class BookCreateRequest {
     @JsonDeserialize(using = CommaSeparatedToListDeserializer.class)
     private List<String> bookTags;
 
-    public Book toEntity(){
+    public Book toEntityWithOutAuthorAndPublisher(){
         return Book.builder()
                 .title(this.title)
                 .description(this.description)

--- a/src/main/java/shop/wannab/book_service/book/entity/Book.java
+++ b/src/main/java/shop/wannab/book_service/book/entity/Book.java
@@ -1,14 +1,27 @@
 package shop.wannab.book_service.book.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.BatchSize;
+import shop.wannab.book_service.author.entity.Author;
+import shop.wannab.book_service.category.entity.Category;
+import shop.wannab.book_service.publisher.entity.Publisher;
 import shop.wannab.book_service.review.entity.Review;
+import shop.wannab.book_service.tag.entity.Tag;
 
 @Builder
 @Getter
@@ -93,4 +106,23 @@ public class Book {
         this.status = status;
     }
 
+    public void addAuthor(Author author) {
+        this.bookAuthors.add(new BookAuthor(this, author));
+    }
+
+    public void addPublisher(Publisher publisher) {
+        this.bookPublishers.add(new BookPublisher(this, publisher));
+    }
+
+    public void addTag(Tag tag) {
+        this.bookTags.add(new BookTag(this, tag));
+    }
+
+    public void addImage(String imageUrl) {
+        this.bookImages.add(new BookImage(this, imageUrl));
+    }
+
+    public void addCategory(Category category) {
+        this.bookCategories.add(new BookCategory(this, category));
+    }
 }

--- a/src/main/java/shop/wannab/book_service/book/entity/BookAuthor.java
+++ b/src/main/java/shop/wannab/book_service/book/entity/BookAuthor.java
@@ -24,4 +24,9 @@ public class BookAuthor {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author_id" , nullable = false)
     private Author author;
+
+    public BookAuthor(Book book, Author author) {
+        this.book = book;
+        this.author = author;
+    }
 }

--- a/src/main/java/shop/wannab/book_service/book/entity/BookCategory.java
+++ b/src/main/java/shop/wannab/book_service/book/entity/BookCategory.java
@@ -24,4 +24,9 @@ public class BookCategory {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id", nullable = false)
     private Book book;
+
+    public BookCategory(Book book, Category category) {
+        this.book = book;
+        this.category = category;
+    }
 }

--- a/src/main/java/shop/wannab/book_service/book/entity/BookImage.java
+++ b/src/main/java/shop/wannab/book_service/book/entity/BookImage.java
@@ -13,9 +13,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Entity(name = "book_images")
 public class BookImage {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long BookImageId;
+    private Long bookImageId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id", nullable = false)
@@ -24,4 +25,9 @@ public class BookImage {
     @NotNull
     @Column(length = 300)
     private String imageUrl;
+
+    public BookImage(Book book, String imageUrl) {
+        this.book = book;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/shop/wannab/book_service/book/entity/BookLike.java
+++ b/src/main/java/shop/wannab/book_service/book/entity/BookLike.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Entity(name = "book_like")
 public class BookLike {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long bookLikeId;

--- a/src/main/java/shop/wannab/book_service/book/entity/BookPublisher.java
+++ b/src/main/java/shop/wannab/book_service/book/entity/BookPublisher.java
@@ -24,4 +24,9 @@ public class BookPublisher {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "publisher_id", nullable = false)
     private Publisher publisher;
+
+    public BookPublisher(Book book, Publisher publisher) {
+        this.book = book;
+        this.publisher = publisher;
+    }
 }

--- a/src/main/java/shop/wannab/book_service/book/entity/BookTag.java
+++ b/src/main/java/shop/wannab/book_service/book/entity/BookTag.java
@@ -24,4 +24,9 @@ public class BookTag {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tag_id", nullable = false)
     private Tag tag;
+
+    public BookTag(Book book, Tag tag) {
+        this.book = book;
+        this.tag = tag;
+    }
 }

--- a/src/main/java/shop/wannab/book_service/book/factory/BookAggregateFactory.java
+++ b/src/main/java/shop/wannab/book_service/book/factory/BookAggregateFactory.java
@@ -1,0 +1,120 @@
+package shop.wannab.book_service.book.factory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import shop.wannab.book_service.author.entity.Author;
+import shop.wannab.book_service.author.repository.AuthorRepository;
+import shop.wannab.book_service.book.controller.request.AladinBookCreateRequest;
+import shop.wannab.book_service.book.controller.request.BookCreateRequest;
+import shop.wannab.book_service.book.entity.Book;
+import shop.wannab.book_service.category.service.CategoryService;
+import shop.wannab.book_service.publisher.entity.Publisher;
+import shop.wannab.book_service.publisher.repository.PublisherRepository;
+import shop.wannab.book_service.tag.entity.Tag;
+import shop.wannab.book_service.tag.repository.TagRepository;
+
+/**
+ * 도서 저장시 논리적인 도메인인 Book Aggregate 를 생성하는 클래스
+ */
+@Component
+@RequiredArgsConstructor
+public class BookAggregateFactory {
+
+    private final AuthorRepository authorRepository;
+    private final PublisherRepository publisherRepository;
+    private final CategoryService categoryService;
+    private final TagRepository tagRepository;
+
+
+    /**
+     * 알라딘 도서 생성 요청을 Aggregate 로 반환하는 메서드
+     * TODO tag 추가 필요
+     */
+    public Book toAggregate(AladinBookCreateRequest req) {
+        Book book = req.toEntityWithOutAuthorAndPublisher();
+
+        Map<String, Author> authors = preloadAuthors(req.authors());
+        req.authors().forEach(name -> book.addAuthor(authors.get(name)));
+
+        Map<String, Publisher> publishers = preloadPublishers(req.publishers());
+        req.publishers().forEach(name -> book.addPublisher(publishers.get(name)));
+
+        categoryService.ensureHierarchy(req.category())
+                .forEach(book::addCategory);
+
+        book.addImage(req.thumbnail());
+
+        return book;
+    }
+
+    /**
+     * 일반 도서 생성 요청을 Aggregate 로 반환하는 메서드
+     * TODO tag 추가 필요
+     */
+    public Book toAggregate(BookCreateRequest req) {
+        Book book = req.toEntityWithOutAuthorAndPublisher();
+
+        Map<String, Author> authors = preloadAuthors(req.getAuthors());
+        req.getAuthors().forEach(name -> book.addAuthor(authors.get(name)));
+
+        Map<String, Publisher> publishers = preloadPublishers(req.getPublishers());
+        req.getPublishers().forEach(name -> book.addPublisher(publishers.get(name)));
+
+        categoryService.ensureHierarchy(req.getCategories())
+                .forEach(book::addCategory);
+
+        req.getBookImages().forEach(book::addImage);
+
+        return book;
+    }
+
+    private Map<String, Author> preloadAuthors(List<String> names) {
+        Map<String, Author> found = authorRepository.findAllByAuthorNameIn(names)
+                .stream().collect(Collectors.toMap(Author::getAuthorName, Function.identity()));
+
+        List<Author> newOnes = names.stream()
+                .filter(n -> !found.containsKey(n))
+                .map(Author::new)
+                .toList();
+        authorRepository.saveAll(newOnes);
+
+        newOnes.forEach(a -> found.put(a.getAuthorName(), a));
+
+        return found;
+    }
+
+    private Map<String, Publisher> preloadPublishers(List<String> names) {
+        Map<String, Publisher> found = publisherRepository.findAllByPublisherNameIn(names)
+                .stream().collect(Collectors.toMap(Publisher::getPublisherName, Function.identity()));
+
+        List<Publisher> newOnes = names.stream()
+                .filter(n -> !found.containsKey(n))
+                .map(Publisher::new)
+                .toList();
+        publisherRepository.saveAll(newOnes);
+
+        newOnes.forEach(a -> found.put(a.getPublisherName(), a));
+
+        return found;
+    }
+
+    private Map<String, Tag> preloadTags(List<String> names) {
+        Map<String, Tag> found = tagRepository.findAllByNameIn(names)
+                .stream().collect(Collectors.toMap(Tag::getName, Function.identity()));
+
+        List<Tag> newOnes = names.stream()
+                .filter(n -> !found.containsKey(n))
+                .map(Tag::new)
+                .toList();
+        tagRepository.saveAll(newOnes);
+
+        newOnes.forEach(t -> found.put(t.getName(), t));
+
+        return found;
+    }
+
+}

--- a/src/main/java/shop/wannab/book_service/book/service/impl/AdminBookServiceImpl.java
+++ b/src/main/java/shop/wannab/book_service/book/service/impl/AdminBookServiceImpl.java
@@ -30,6 +30,7 @@ import shop.wannab.book_service.category.entity.Category;
 import shop.wannab.book_service.category.exception.CategoryApiException;
 import shop.wannab.book_service.category.exception.CategoryErrorCode;
 import shop.wannab.book_service.category.repository.CategoryRepository;
+import shop.wannab.book_service.category.service.CategoryService;
 import shop.wannab.book_service.publisher.entity.Publisher;
 import shop.wannab.book_service.publisher.repository.PublisherRepository;
 import shop.wannab.book_service.tag.entity.Tag;
@@ -45,6 +46,7 @@ public class AdminBookServiceImpl implements AdminBookService {
     private final PublisherRepository publisherRepository;
     private final TagRepository tagRepository;
     private final CategoryRepository categoryRepository;
+    private final CategoryService categoryService;
 
     // 도서 리스트 조회
     @Override
@@ -70,7 +72,7 @@ public class AdminBookServiceImpl implements AdminBookService {
             throw new BookApiException(BookErrorCode.DUPLICATE_BOOK);
         }
 
-        Book book = request.toEntity();
+        Book book = request.toEntityWithOutAuthorAndPublisher();
 
         List<BookAuthor> bookAuthors = request.getAuthors().stream()
                 .map(authorName ->{
@@ -111,6 +113,7 @@ public class AdminBookServiceImpl implements AdminBookService {
                         .imageUrl(imageUrl)
                         .build())
                 .toList();
+
         List<BookCategory> categories = ensureCategoryHierarchy(request.getCategories(),book);
 
         book.getBookCategories().addAll(categories);
@@ -138,7 +141,8 @@ public class AdminBookServiceImpl implements AdminBookService {
                 request.getStock(),
                 request.getBookChapter(),
                 request.getIsbn(),
-                request.isStatus());
+                request.isStatus()
+        );
 
         book.getBookAuthors().clear();
         book.getBookPublishers().clear();
@@ -185,7 +189,7 @@ public class AdminBookServiceImpl implements AdminBookService {
                         .imageUrl(imageUrl)
                         .build())
                 .toList();
-        List<BookCategory> categories = ensureCategoryHierarchy(request.getCategories(),book);
+        List<BookCategory> categories = ensureCategoryHierarchy(request.getCategories(), book);
 
         book.getBookCategories().addAll(categories);
         book.getBookImages().addAll(bookImages);
@@ -204,7 +208,7 @@ public class AdminBookServiceImpl implements AdminBookService {
         bookRepository.deleteBookStock(bookId);
     }
 
-    private List<BookCategory> ensureCategoryHierarchy(List<String> categoryNames,Book book) {
+    private List<BookCategory> ensureCategoryHierarchy(List<String> categoryNames, Book book) {
         if (categoryNames.size() < 2) {
             throw new CategoryApiException(CategoryErrorCode.INVALID_CATEGORY_HIERARCHY);
         }

--- a/src/main/java/shop/wannab/book_service/book/updater/BookAggregateUpdater.java
+++ b/src/main/java/shop/wannab/book_service/book/updater/BookAggregateUpdater.java
@@ -1,0 +1,149 @@
+package shop.wannab.book_service.book.updater;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import shop.wannab.book_service.author.entity.Author;
+import shop.wannab.book_service.author.repository.AuthorRepository;
+import shop.wannab.book_service.book.controller.request.BookUpdateRequest;
+import shop.wannab.book_service.book.entity.Book;
+import shop.wannab.book_service.book.entity.BookAuthor;
+import shop.wannab.book_service.book.entity.BookCategory;
+import shop.wannab.book_service.book.entity.BookImage;
+import shop.wannab.book_service.book.entity.BookPublisher;
+import shop.wannab.book_service.book.entity.BookTag;
+import shop.wannab.book_service.category.entity.Category;
+import shop.wannab.book_service.category.service.CategoryService;
+import shop.wannab.book_service.publisher.entity.Publisher;
+import shop.wannab.book_service.publisher.repository.PublisherRepository;
+import shop.wannab.book_service.tag.entity.Tag;
+import shop.wannab.book_service.tag.repository.TagRepository;
+
+/**
+ * 도서 업데이트시 Book Aggregate 를 수정하는 클래스
+ */
+@Component
+@RequiredArgsConstructor
+public class BookAggregateUpdater {
+
+    private final AuthorRepository authorRepository;
+    private final PublisherRepository publisherRepository;
+    private final TagRepository tagRepository;
+    private final CategoryService categoryService;
+
+    @Transactional
+    public void apply(Book book, BookUpdateRequest req) {
+
+        book.updateInfo(
+                req.getTitle(), req.getDescription(), req.getPublicationDate(),
+                req.getOriginPrice(), req.getSalesPrice(), req.getStock(),
+                req.getBookChapter(), req.getIsbn(), req.isStatus());
+
+        Map<String, Author> authors = preloadAuthors(req.getAuthors());
+        syncCollection(
+                book.getBookAuthors(),
+                req.getAuthors(),
+                a -> a.getAuthor().getAuthorName(),
+                name -> new BookAuthor(book, authors.get(name)));
+
+        Map<String, Publisher> publishers = preloadPublishers(req.getPublishers());
+        syncCollection(
+                book.getBookPublishers(),
+                req.getPublishers(),
+                p -> p.getPublisher().getPublisherName(),
+                name -> new BookPublisher(book, publishers.get(name)));
+
+        Map<String, Tag> tags = preloadTags(req.getBookTags());
+        syncCollection(
+                book.getBookTags(),
+                req.getBookTags(),
+                t -> t.getTag().getName(),
+                name -> new BookTag(book, tags.get(name)));
+
+        syncCollection(
+                book.getBookImages(),
+                req.getBookImages(),
+                BookImage::getImageUrl,
+                url -> new BookImage(book, url));
+
+        List<Category> ensured = categoryService.ensureHierarchy(req.getCategories());
+        syncCollection(
+                book.getBookCategories(),
+                ensured.stream().map(Category::getName).toList(),
+                bc -> bc.getCategory().getName(),
+                name -> new BookCategory(book,
+                        ensured.stream()
+                                .filter(c -> c.getName().equals(name))
+                                .findFirst().orElseThrow()));
+    }
+
+    /**
+     * 업데이트시, 기존 Book Aggregate, 업데이트 Book Aggregate 의 차이점을 계산하는 메서드
+     */
+    private <T, K> void syncCollection(Collection<T> target,
+                                       Collection<K> desiredKeys,
+                                       Function<T, K> keyExtractor,
+                                       Function<K, T> creator) {
+
+        Set<K> present = target.stream().map(keyExtractor).collect(Collectors.toSet());
+
+        target.removeIf(e -> !desiredKeys.contains(keyExtractor.apply(e)));
+
+        desiredKeys.stream()
+                .filter(k -> !present.contains(k))
+                .map(creator)
+                .forEach(target::add);
+    }
+
+    private Map<String, Author> preloadAuthors(List<String> names) {
+        Map<String, Author> found = authorRepository.findAllByAuthorNameIn(names)
+                .stream().collect(Collectors.toMap(Author::getAuthorName, Function.identity()));
+
+        List<Author> newOnes = names.stream()
+                .filter(n -> !found.containsKey(n))
+                .map(Author::new)
+                .toList();
+        authorRepository.saveAll(newOnes);
+
+        newOnes.forEach(a -> found.put(a.getAuthorName(), a));
+
+        return found;
+    }
+
+    private Map<String, Publisher> preloadPublishers(List<String> names) {
+        Map<String, Publisher> found = publisherRepository.findAllByPublisherNameIn(names)
+                .stream().collect(Collectors.toMap(Publisher::getPublisherName, Function.identity()));
+
+        List<Publisher> newOnes = names.stream()
+                .filter(n -> !found.containsKey(n))
+                .map(Publisher::new)
+                .toList();
+        publisherRepository.saveAll(newOnes);
+
+        newOnes.forEach(a -> found.put(a.getPublisherName(), a));
+
+        return found;
+    }
+
+    private Map<String, Tag> preloadTags(List<String> names) {
+        Map<String, Tag> found = tagRepository.findAllByNameIn(names)
+                .stream().collect(Collectors.toMap(Tag::getName, Function.identity()));
+
+        List<Tag> newOnes = names.stream()
+                .filter(n -> !found.containsKey(n))
+                .map(Tag::new)
+                .toList();
+        tagRepository.saveAll(newOnes);
+
+        newOnes.forEach(t -> found.put(t.getName(), t));
+
+        return found;
+    }
+}
+

--- a/src/main/java/shop/wannab/book_service/category/repository/CategoryRepository.java
+++ b/src/main/java/shop/wannab/book_service/category/repository/CategoryRepository.java
@@ -1,5 +1,6 @@
 package shop.wannab.book_service.category.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,5 @@ import shop.wannab.book_service.category.entity.Category;
 public interface CategoryRepository extends JpaRepository<Category, Long>, CategoryQueryRepository {
     List<Category> findByParentIsNull();
     Optional<Category> findByName(String categoryName);
+    List<Category> findAllByNameIn(Collection<String> names);
 }

--- a/src/main/java/shop/wannab/book_service/category/service/CategoryService.java
+++ b/src/main/java/shop/wannab/book_service/category/service/CategoryService.java
@@ -1,12 +1,12 @@
 package shop.wannab.book_service.category.service;
 
-import jakarta.persistence.EntityNotFoundException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,7 +17,6 @@ import shop.wannab.book_service.book.entity.BookCategory;
 import shop.wannab.book_service.book.repository.BookCategoryRepository;
 import shop.wannab.book_service.category.dto.CategoryHierarchyDto;
 import shop.wannab.book_service.category.dto.request.CategoryCreateRequest;
-import shop.wannab.book_service.category.dto.response.CategoryIdsResponse;
 import shop.wannab.book_service.category.dto.response.CategoryResponse;
 import shop.wannab.book_service.category.entity.Category;
 import shop.wannab.book_service.category.exception.CategoryApiException;
@@ -112,7 +111,7 @@ public class CategoryService {
         return categoryNames;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<CategoryResponse> getAllParentCategory() {
         return categoryRepository.findParentCategories();
     }
@@ -136,5 +135,56 @@ public class CategoryService {
             }
         }
         return bookToAllCategoryIdsMap;
+    }
+
+    /**
+     * depth-2 hierarchy 까지 지원
+     * 입력된 카테고리가 1개면, 1개만 조회 및 없으면 저장
+     * 2개면, 2개 조회 및 저장
+     * 3개면, 1번, 2번 인덱스 조회 및 저장
+     */
+    @Transactional
+    public List<Category> ensureHierarchy(List<String> names) {
+        if (names == null || names.isEmpty()) {
+            throw new CategoryApiException(CategoryErrorCode.INVALID_CATEGORY_HIERARCHY);
+        }
+
+        List<String> categoryNames = switch (names.size()) {
+            case 1 -> List.of(names.get(0));
+            case 2 -> List.of(names.get(0), names.get(1));
+            default -> List.of(names.get(1), names.get(2));
+        };
+
+        List<Category> found = categoryRepository.findAllByNameIn(categoryNames);
+        Map<String, Category> map = found.stream()
+                .collect(Collectors.toMap(Category::getName, Function.identity()));
+
+        if (names.size() == 1) {
+            String parentName = names.getFirst();
+            Category parent = map.computeIfAbsent(parentName, n -> {
+                Category c = new Category();
+                c.setName(n);
+                return categoryRepository.save(c);
+            });
+            return List.of(parent);
+        } else {
+            String parentName = names.size() == 2 ? names.get(0) : names.get(1);
+            String childName  = names.size() == 2 ? names.get(1) : names.get(2);
+
+            Category parent = map.computeIfAbsent(parentName, n -> {
+                Category c = new Category();
+                c.setName(n);
+                return categoryRepository.save(c);
+            });
+
+            Category child = map.computeIfAbsent(childName, n -> {
+                Category c = new Category();
+                c.setName(n);
+                c.setParent(parent);
+                return categoryRepository.save(c);
+            });
+
+            return List.of(parent, child);
+        }
     }
 }

--- a/src/main/java/shop/wannab/book_service/global/properties/AladinKeyProperties.java
+++ b/src/main/java/shop/wannab/book_service/global/properties/AladinKeyProperties.java
@@ -1,0 +1,14 @@
+package shop.wannab.book_service.global.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter @Setter
+@Component
+@ConfigurationProperties(prefix = "aladin.api")
+public class AladinKeyProperties {
+    private String baseUrl;
+    private String ttbKey;
+}

--- a/src/main/java/shop/wannab/book_service/publisher/entity/Publisher.java
+++ b/src/main/java/shop/wannab/book_service/publisher/entity/Publisher.java
@@ -20,4 +20,8 @@ public class Publisher {
     @NotNull
     @Column(length = 50)
     private String publisherName;
+
+    public Publisher(String publisherName) {
+        this.publisherName = publisherName;
+    }
 }

--- a/src/main/java/shop/wannab/book_service/publisher/repository/PublisherRepository.java
+++ b/src/main/java/shop/wannab/book_service/publisher/repository/PublisherRepository.java
@@ -1,5 +1,6 @@
 package shop.wannab.book_service.publisher.repository;
 
+import java.util.Collection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import shop.wannab.book_service.publisher.entity.Publisher;
 
@@ -8,4 +9,5 @@ import java.util.Optional;
 public interface PublisherRepository extends JpaRepository<Publisher,Long> {
     Optional<Publisher> findPublisherByPublisherName(String publisherName);
 
+    Collection<Publisher> findAllByPublisherNameIn(Collection<String> publisherNames);
 }

--- a/src/main/java/shop/wannab/book_service/tag/entity/Tag.java
+++ b/src/main/java/shop/wannab/book_service/tag/entity/Tag.java
@@ -30,6 +30,10 @@ public class Tag {
         return deletedAt != null;
     }
 
+    public Tag(String name) {
+        this.name = name;
+    }
+
     public static Tag create(String name) {
         return new Tag(null, name, null);
     }

--- a/src/main/java/shop/wannab/book_service/tag/repository/TagRepository.java
+++ b/src/main/java/shop/wannab/book_service/tag/repository/TagRepository.java
@@ -1,9 +1,12 @@
 package shop.wannab.book_service.tag.repository;
 
+import java.util.Collection;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import shop.wannab.book_service.tag.entity.Tag;
 
 public interface TagRepository extends JpaRepository<Tag, Long>, TagQueryRepository {
     Optional<Tag> findTagByName(String name);
+
+    Collection<Tag> findAllByNameIn(Collection<String> names);
 }

--- a/src/main/resources/application-ci.yml
+++ b/src/main/resources/application-ci.yml
@@ -49,7 +49,7 @@ management:
 aladin:
   api:
     base-url: "http://secret/"
-    ttbkey: "secret"
+    ttb-key: "secret"
 
 elasticsearch:
   host: localhost

--- a/src/test/java/shop/wannab/book_service/book/service/AdminBookServiceImplTest.java
+++ b/src/test/java/shop/wannab/book_service/book/service/AdminBookServiceImplTest.java
@@ -80,7 +80,7 @@ class AdminBookServiceImplTest {
 
         when(request.getIsbn()).thenReturn("123456");
         when(bookRepository.existsByIsbn("123456")).thenReturn(false);
-        when(request.toEntity()).thenReturn(book);
+        when(request.toEntityWithOutAuthorAndPublisher()).thenReturn(book);
         when(request.getAuthors()).thenReturn(List.of("홍길동"));
         when(request.getPublishers()).thenReturn(List.of("출판사"));
         when(request.getBookTags()).thenReturn(List.of("태그"));


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?

1. 현재 알라딘 도서 저장 시, 서비스 로직이 과도한 책임을 가지고 있는 문제점이 있습니다.
> aggregate를 도입하여 로직을 리팩토링 하였습니다.

2. 도서 저장 시, 카테고리 계층 정보를 BookService 클래스에서 처리하고 있어, SRP 원칙을 위배하고 있습니다.
> CategoryService 클래스에서 처리하도록 리팩토링 하였습니다.

3. ttbkey가 Value 어노테이션을 통해서 필드 주입되어 강하게 결합되어 있습니다.
> 커플링을 느슨하게 만들었습니다.

## 🔎 작업 상세 내용
- [x] Aggregate 팩토리 클래스 구현
- [x] CategoryService 클래스로 카테고리 계층 정보 구현 메서드 이동
- [x] ConfigurationProperties를 활용하여 low coupling 으로 리팩토링
      
## ⏰ Pull Request 마감시간
> 14일 15시

## 🔗 관련 이슈
Closes #91 
